### PR TITLE
feat: added new feature, admin can now create a banner

### DIFF
--- a/src/lib/components/app/banner.svelte
+++ b/src/lib/components/app/banner.svelte
@@ -1,0 +1,8 @@
+<script>
+	import * as Alert from '$lib/components/ui/alert';
+	let { message } = $props();
+</script>
+
+<Alert.Root class="mb-3 rounded-[5px] bg-blue-500 p-2 text-white">
+	<Alert.Description>{message}</Alert.Description>
+</Alert.Root>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -35,3 +35,4 @@ export { default as Library } from 'lucide-svelte/icons/library';
 export { default as Eye } from 'lucide-svelte/icons/eye';
 export { default as EyeClosed } from 'lucide-svelte/icons/eye-closed';
 export { default as Citrus } from 'lucide-svelte/icons/citrus';
+export { default as MessageCircleWarning } from 'lucide-svelte/icons/message-circle-warning';

--- a/src/lib/components/ui/switch/index.ts
+++ b/src/lib/components/ui/switch/index.ts
@@ -1,0 +1,7 @@
+import Root from "./switch.svelte";
+
+export {
+	Root,
+	//
+	Root as Switch,
+};

--- a/src/lib/components/ui/switch/switch.svelte
+++ b/src/lib/components/ui/switch/switch.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Switch as SwitchPrimitive, type WithoutChildrenOrChild } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> = $props();
+</script>
+
+<SwitchPrimitive.Root
+	bind:ref
+	bind:checked
+	class={cn(
+		"focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	{...restProps}
+>
+	<SwitchPrimitive.Thumb
+		class={cn(
+			"bg-background pointer-events-none block size-4 rounded-full shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+		)}
+	/>
+</SwitchPrimitive.Root>

--- a/src/lib/server/db/init.ts
+++ b/src/lib/server/db/init.ts
@@ -2,6 +2,10 @@ import type { Service } from './schema';
 import { getAllServices, insertService } from '../backend/services-service';
 import { logger } from '../logger';
 
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+
 export const init = async () => {
 	const result = await getAllServices();
 	if (result.length === 0) {
@@ -9,6 +13,8 @@ export const init = async () => {
 			await insertService(ser);
 		});
 	}
+
+	db.insert(table.banner).values({ id: 1, message: '', visible: false });
 
 	logger.info('Services table seeded successfully!');
 };

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -36,7 +36,14 @@ export const service = sqliteTable('service', {
 	description: text('description').notNull()
 });
 
+export const banner = sqliteTable('banner', {
+	id: integer().primaryKey(),
+	message: text('message'),
+	visible: integer({ mode: 'boolean' })
+});
+
 export type Session = typeof session.$inferSelect;
 export type User = typeof user.$inferSelect;
 export type Reservation = typeof reservation.$inferSelect;
 export type Service = typeof service.$inferSelect;
+export type Banner = typeof banner.$inferSelect;

--- a/src/routes/(protected)/(admin)/dashboard/+layout.svelte
+++ b/src/routes/(protected)/(admin)/dashboard/+layout.svelte
@@ -7,20 +7,21 @@
 	type DashBoardItem = {
 		href: string;
 		name: string;
-		active: boolean;
 	};
 
 	const dashboardItems: DashBoardItem[] = [
 		{
 			href: 'reservations',
-			name: 'Prenotazioni',
-			active: true
+			name: 'Prenotazioni'
 		},
 
 		{
 			href: 'calendar',
-			name: 'Calendario',
-			active: false
+			name: 'Calendario'
+		},
+		{
+			href: 'banner',
+			name: 'Banner'
 		}
 	];
 

--- a/src/routes/(protected)/(admin)/dashboard/banner/+page.server.ts
+++ b/src/routes/(protected)/(admin)/dashboard/banner/+page.server.ts
@@ -1,0 +1,21 @@
+import type { Actions } from './$types';
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	return { banner: await db.select().from(table.banner).where(eq(table.banner.id, 1)).get() };
+};
+export const actions: Actions = {
+	default: async ({ request }) => {
+		const data = await request.formData();
+
+		const message = data.get('message') as string;
+
+		// Convert to boolean
+		const visible = (data.get('visible') as string) === 'on';
+
+		await db.update(table.banner).set({ message, visible }).where(eq(table.banner.id, 1));
+	}
+};

--- a/src/routes/(protected)/(admin)/dashboard/banner/+page.svelte
+++ b/src/routes/(protected)/(admin)/dashboard/banner/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Switch } from '$lib/components/ui/switch';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	let message = $state(data.banner?.message ?? '');
+	let visible = $state(data.banner?.visible ?? false);
+
+	let saveDisabled = $derived(
+		message === data.banner?.message && visible === data.banner.visible
+	);
+</script>
+
+<form method="post">
+	<Input
+		bind:value={message}
+		name="message"
+		placeholder="Banner da inserire"
+		type="textarea"
+		class="mb-4"
+	/>
+
+	<div class="flex items-center space-x-2">
+		<Switch bind:checked={visible} name="visible" id="airplane-mode" />
+		<Label for="airplane-mode">Visibilità banner</Label>
+	</div>
+	<Button class="mt-4" disabled={saveDisabled} type="submit">Salva</Button>
+</form>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,6 +1,9 @@
 import type { LayoutServerLoad } from './$types';
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
 
-export const load: LayoutServerLoad = async ({ locals, url }) => {
-	const success = url.searchParams.get('success');
-	return { user: locals.user, title: 'Home | ', success };
+export const load: LayoutServerLoad = async ({ locals }) => {
+	const banner = await db.select().from(table.banner).get();
+
+	return { user: locals.user, title: 'Home | ', banner };
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
 	import { enhance } from '$app/forms';
 	import { page } from '$app/state';
 	import { Toaster } from '$lib/components/ui/sonner';
+	import Banner from '$lib/components/app/banner.svelte';
 	import '../app.css';
 
 	let { data, children } = $props();
@@ -74,8 +75,12 @@
 				<Modeswitcher />
 			</div>
 		</div>
+
 		<div class="flex min-h-0 flex-1 flex-col">
 			<div class="flex-1 p-3">
+				{#if data.banner?.visible}
+					<Banner message={data.banner.message} />
+				{/if}
 				{@render children()}
 			</div>
 			<Footer />


### PR DESCRIPTION
This pull request introduces a new banner feature for the admin dashboard and makes several related changes across multiple files. The most important changes include the creation of new components and database schema modifications to support the banner functionality.

### New Banner Feature:

* [`src/lib/components/app/banner.svelte`](diffhunk://#diff-91b6b3552ad2694db3ff79fdb45b742a4a80c2ce10462034efd785d7f423d67aR1-R14): Added a new `Banner` component that displays a message using the `Alert` component.
* [`src/routes/(protected)/(admin)/dashboard/banner/+page.svelte`](diffhunk://#diff-7aee0669f6c73aff146dad0c1be9b672f42be83ec4e8b86672b1519e70c3489eR1-R32): Created a new page for managing the banner, including form elements to update the banner's message and visibility.
* [`src/routes/(protected)/(admin)/dashboard/banner/+page.server.ts`](diffhunk://#diff-dfa700b239d2e20fb38f6af4fd3f3c207d0ad716ce3c33e89649f54a93afa322R1-R21): Implemented server-side logic to load and update the banner data in the database.

### Database Schema Changes:

* [`src/lib/server/db/schema.ts`](diffhunk://#diff-bfcd9b7537135d04bf11ec331e61e43db9a834ee401e7b3d7e3dc05c94c7b4e0R39-R49): Added a new `banner` table to store the banner's message and visibility status.
* [`src/lib/server/db/init.ts`](diffhunk://#diff-90401e22f4446aa3193d26c031064d51d227645a2db15b90bcf0340e855e0e35R17-R18): Modified the database initialization script to insert a default banner entry.

### Integration with Layout:

* [`src/routes/+layout.server.ts`](diffhunk://#diff-49dc14268e89f5a2bf852134625940dc89992c8e534f34bbbacc1106f1dac4b1R2-R8): Updated the layout server load function to fetch the banner data.
* [`src/routes/+layout.svelte`](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR78-R83): Integrated the `Banner` component into the main layout, displaying it conditionally based on its visibility status.